### PR TITLE
Implement OrbitingCamera: MouseButtonToOrbit option

### DIFF
--- a/Assets/SeeThru/Editor/SeeThru/Inspectors/OrbitingCameraInspector.cs
+++ b/Assets/SeeThru/Editor/SeeThru/Inspectors/OrbitingCameraInspector.cs
@@ -19,6 +19,7 @@ namespace SeeThru.Inspectors
         SerializedProperty m_VerticalAxis;
         SerializedProperty m_HorizontalSensitivity;
         SerializedProperty m_VerticalSensitivity;
+        SerializedProperty m_MouseButtonToOrbit;
         SerializedProperty m_TargetDistance;
         SerializedProperty m_MinTargetDistance;
         SerializedProperty m_MaxTargetDistance;
@@ -45,6 +46,7 @@ namespace SeeThru.Inspectors
             m_VerticalAxis = serializedObject.FindProperty("VerticalAxis");
             m_HorizontalSensitivity = serializedObject.FindProperty("HorizontalSensitivity");
             m_VerticalSensitivity = serializedObject.FindProperty("VerticalSensitivity");
+            m_MouseButtonToOrbit = serializedObject.FindProperty("MouseButtonToOrbit");
             m_TargetDistance = serializedObject.FindProperty("TargetDistance");
             m_MinTargetDistance = serializedObject.FindProperty("MinTargetDistance");
             m_MaxTargetDistance = serializedObject.FindProperty("MaxTargetDistance");
@@ -84,6 +86,7 @@ namespace SeeThru.Inspectors
             EditorGUILayout.PropertyField(m_VerticalAxis);
             EditorGUILayout.PropertyField(m_HorizontalSensitivity);
             EditorGUILayout.PropertyField(m_VerticalSensitivity);
+            EditorGUILayout.PropertyField(m_MouseButtonToOrbit);
             EditorGUILayout.PropertyField(m_TargetDistance);
             EditorGUILayout.PropertyField(m_MinTargetDistance);
             EditorGUILayout.PropertyField(m_MaxTargetDistance);

--- a/Assets/SeeThru/Scripts/SeeThru/Cameras/OrbitingCamera.cs
+++ b/Assets/SeeThru/Scripts/SeeThru/Cameras/OrbitingCamera.cs
@@ -21,6 +21,8 @@ namespace SeeThru.Cameras
         public float HorizontalSensitivity = 1f;
         [Min(0f), Tooltip("The Vertical Axis Sensitivity")]
         public float VerticalSensitivity = 1f;
+        [Tooltip("Whether to require mouse button to be held to orbit")]
+        public bool MouseButtonToOrbit = false;
 
         [Header("OrbitingCamera - Distance")]
         [Min(0f), Tooltip("How far away from the target in focus is the camera.")]
@@ -116,23 +118,21 @@ namespace SeeThru.Cameras
                     }
                     TargetDistance = Mathf.Clamp(TargetDistance, MinTargetDistance, MaxTargetDistance);
                     SetCameraPosition();
-                    Quaternion lookRotation;
-                    if (StayBehindTarget == false ? SetRotation() : SetRotation() || OrbitBehind())
-                    {
-                        _orbitAngles.x = Mathf.Clamp(_orbitAngles.x, MinVerticalAngle, MaxVerticalAngle);
-                        if (_orbitAngles.y < 0f)
-                        {
-                            _orbitAngles.y += 360f;
-                        }
-                        else if (_orbitAngles.y >= 360f)
-                        {
-                            _orbitAngles.y -= 360f;
-                        }
-                        lookRotation = Quaternion.Euler(_orbitAngles);
-                    }
-                    else
-                    {
-                        lookRotation = transform.rotation;
+                    Quaternion lookRotation = lookRotation = transform.rotation;
+                    if(!MouseButtonToOrbit || Input.GetMouseButton(0)){
+                      if (StayBehindTarget == false ? SetRotation() : SetRotation() || OrbitBehind())
+                      {
+                          _orbitAngles.x = Mathf.Clamp(_orbitAngles.x, MinVerticalAngle, MaxVerticalAngle);
+                          if (_orbitAngles.y < 0f)
+                          {
+                              _orbitAngles.y += 360f;
+                          }
+                          else if (_orbitAngles.y >= 360f)
+                          {
+                              _orbitAngles.y -= 360f;
+                          }
+                          lookRotation = Quaternion.Euler(_orbitAngles);
+                      }
                     }
 
                     Vector3 lookDirection = lookRotation * Vector3.forward;


### PR DESCRIPTION
Greetings! Thanks for the great Unity plugin.

This patch extends OrbitingCamera to support a flag wherein if set, it will require the left mouse button to be held to trigger orbiting functionality.